### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/src/algorithms/algorithms.mbti
+++ b/src/algorithms/algorithms.mbti
@@ -55,6 +55,7 @@ fn DiffOp::shift_right(Self, Int) -> Unit
 fn DiffOp::shrink_left(Self, Int) -> Unit
 fn DiffOp::shrink_right(Self, Int) -> Unit
 impl Compare for DiffOp
+impl Debug for DiffOp
 impl Eq for DiffOp
 impl Hash for DiffOp
 impl Show for DiffOp
@@ -122,4 +123,3 @@ pub(open) trait DiffHook {
   replace(Self, Int, Int, Int, Int) -> Result[Unit, Error] = _
   finish(Self) -> Result[Unit, Error] = _
 }
-

--- a/src/algorithms/myers.mbt
+++ b/src/algorithms/myers.mbt
@@ -337,9 +337,16 @@ test "test_diff" {
     Range::new(0, b.length()),
   )
   let ops = capture.into_ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=3), Delete(old_index=3, old_len=1, new_index=4), Insert(old_index=3, new_index=3, new_len=1), Equal(old_index=4, new_index=4, len=1)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=3),
+      #|  Delete(old_index=3, old_len=1, new_index=4),
+      #|  Insert(old_index=3, new_index=3, new_len=1),
+      #|  Equal(old_index=4, new_index=4, len=1),
+      #|]
+    ),
   )
 
   // Test 2: Multiple changes with duplicates
@@ -354,9 +361,19 @@ test "test_diff" {
     Range::new(0, b.length()),
   )
   let ops = capture.into_ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=3), Delete(old_index=3, old_len=1, new_index=4), Insert(old_index=3, new_index=3, new_len=1), Insert(old_index=4, new_index=4, new_len=1), Equal(old_index=4, new_index=5, len=2), Delete(old_index=6, old_len=2, new_index=7), Insert(old_index=8, new_index=7, new_len=1)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=3),
+      #|  Delete(old_index=3, old_len=1, new_index=4),
+      #|  Insert(old_index=3, new_index=3, new_len=1),
+      #|  Insert(old_index=4, new_index=4, new_len=1),
+      #|  Equal(old_index=4, new_index=5, len=2),
+      #|  Delete(old_index=6, old_len=2, new_index=7),
+      #|  Insert(old_index=8, new_index=7, new_len=1),
+      #|]
+    ),
   )
 
   // Test 3: Insertions and deletions
@@ -371,8 +388,16 @@ test "test_diff" {
     Range::new(0, b.length()),
   )
   let ops = capture.into_ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=2), Delete(old_index=2, old_len=1, new_index=2), Equal(old_index=3, new_index=2, len=2), Insert(old_index=5, new_index=4, new_len=1), Insert(old_index=5, new_index=5, new_len=1)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=2),
+      #|  Delete(old_index=2, old_len=1, new_index=2),
+      #|  Equal(old_index=3, new_index=2, len=2),
+      #|  Insert(old_index=5, new_index=4, new_len=1),
+      #|  Insert(old_index=5, new_index=5, new_len=1),
+      #|]
+    ),
   )
 }

--- a/src/algorithms/patience.mbt
+++ b/src/algorithms/patience.mbt
@@ -195,9 +195,19 @@ test "test_patience" {
     Range::new(0, b.length()),
   )
   let ops = d.into_inner().ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Replace(old_index=0, old_len=1, new_index=0, new_len=1), Equal(old_index=1, new_index=1, len=3), Replace(old_index=4, old_len=1, new_index=4, new_len=2), Equal(old_index=5, new_index=6, len=2), Replace(old_index=7, old_len=2, new_index=8, new_len=1), Equal(old_index=9, new_index=9, len=1), Replace(old_index=10, old_len=1, new_index=10, new_len=1)]",
+    content=(
+      #|[
+      #|  Replace(old_index=0, old_len=1, new_index=0, new_len=1),
+      #|  Equal(old_index=1, new_index=1, len=3),
+      #|  Replace(old_index=4, old_len=1, new_index=4, new_len=2),
+      #|  Equal(old_index=5, new_index=6, len=2),
+      #|  Replace(old_index=7, old_len=2, new_index=8, new_len=1),
+      #|  Equal(old_index=9, new_index=9, len=1),
+      #|  Replace(old_index=10, old_len=1, new_index=10, new_len=1),
+      #|]
+    ),
   )
 }
 
@@ -216,8 +226,13 @@ test "test_patience_2" {
     Range::new(0, b.length()),
   )
   let ops = d.into_inner().ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=3), Delete(old_index=3, old_len=1, new_index=3)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=3),
+      #|  Delete(old_index=3, old_len=1, new_index=3),
+      #|]
+    ),
   )
 }

--- a/src/algorithms/pkg.generated.mbti
+++ b/src/algorithms/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "ruifeng/diff/algorithms"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn[T : Eq] cleanup_diff_ops(Array[T], Array[T], Array[DiffOp]) -> Unit
 
@@ -42,7 +46,7 @@ pub(all) enum DiffOp {
   Delete(mut old_index~ : Int, mut old_len~ : Int, mut new_index~ : Int)
   Insert(mut old_index~ : Int, mut new_index~ : Int, mut new_len~ : Int)
   Replace(mut old_index~ : Int, mut old_len~ : Int, mut new_index~ : Int, mut new_len~ : Int)
-} derive(Compare, Eq, Hash)
+} derive(Compare, Eq, Hash, @debug.Debug)
 pub fn[D : DiffHook] DiffOp::apply_to_hook(Self, D) -> Result[Unit, Error]
 pub fn DiffOp::grow_left(Self, Int) -> Unit
 pub fn DiffOp::grow_right(Self, Int) -> Unit

--- a/src/algorithms/replace.mbt
+++ b/src/algorithms/replace.mbt
@@ -170,9 +170,17 @@ test "test_myers_replace" {
     Range::new(0, b.length()),
   )
   let ops = capture.ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=1), Replace(old_index=1, old_len=1, new_index=1, new_len=1), Equal(old_index=2, new_index=2, len=3), Replace(old_index=5, old_len=1, new_index=5, new_len=1), Equal(old_index=6, new_index=6, len=3)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=1),
+      #|  Replace(old_index=1, old_len=1, new_index=1, new_len=1),
+      #|  Equal(old_index=2, new_index=2, len=3),
+      #|  Replace(old_index=5, old_len=1, new_index=5, new_len=1),
+      #|  Equal(old_index=6, new_index=6, len=3),
+      #|]
+    ),
   )
 }
 
@@ -191,8 +199,13 @@ test "test_replace" {
     Range::new(0, b.length()),
   )
   let ops = capture.ops()
-  inspect(
+  debug_inspect(
     ops,
-    content="[Equal(old_index=0, new_index=0, len=3), Replace(old_index=3, old_len=2, new_index=3, new_len=3)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=3),
+      #|  Replace(old_index=3, old_len=2, new_index=3, new_len=3),
+      #|]
+    ),
   )
 }

--- a/src/algorithms/type.mbt
+++ b/src/algorithms/type.mbt
@@ -14,7 +14,7 @@ pub(all) enum DiffOp {
     mut new_index~ : Int,
     mut new_len~ : Int
   )
-} derive(Eq, Hash, Compare)
+} derive(Eq, Hash, Compare, Debug)
 
 ///|
 pub impl Show for DiffOp with output(self, logger) {

--- a/src/algorithms/utils.mbt
+++ b/src/algorithms/utils.mbt
@@ -74,7 +74,7 @@ pub fn[T : Eq + Hash] unique(
   range : Range,
 ) -> Array[UniqueItem[T]] {
   // Step 1: Build frequency map
-  let map : @hashmap.HashMap[T, Int?] = @hashmap.HashMap::new()
+  let map : @hashmap.HashMap[T, Int?] = @hashmap.HashMap([])
   for i in range {
     match map.get(array[i]) {
       None => map[array[i]] = Some(i) // First occurrence

--- a/src/algorithms/utils.mbt
+++ b/src/algorithms/utils.mbt
@@ -74,7 +74,7 @@ pub fn[T : Eq + Hash] unique(
   range : Range,
 ) -> Array[UniqueItem[T]] {
   // Step 1: Build frequency map
-  let map : @hashmap.HashMap[T, Int?] = @hashmap.HashMap([])
+  let map : @hashmap.HashMap[T, Int?] = HashMap([])
   for i in range {
     match map.get(array[i]) {
       None => map[array[i]] = Some(i) // First occurrence

--- a/src/core.mbt
+++ b/src/core.mbt
@@ -114,9 +114,16 @@ test "test_diff" {
   let a = [1, 2, 3, 4, 5, 8, 9]
   let b = [1, 2, 0, 4, 5, 6, 7]
   let diffs = diff(a, b)
-  inspect(
+  debug_inspect(
     diffs,
-    content="[Equal(old_index=0, new_index=0, len=2), Replace(old_index=2, old_len=1, new_index=2, new_len=1), Equal(old_index=3, new_index=3, len=2), Replace(old_index=5, old_len=2, new_index=5, new_len=2)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=2),
+      #|  Replace(old_index=2, old_len=1, new_index=2, new_len=1),
+      #|  Equal(old_index=3, new_index=3, len=2),
+      #|  Replace(old_index=5, old_len=2, new_index=5, new_len=2),
+      #|]
+    ),
   )
 }
 
@@ -134,8 +141,15 @@ test "test_diff_with_compact" {
   let old = "a b c d".to_array()
   let new = "a b d c".to_array()
   let compact_diffs = diff_with_compact(old, new)
-  inspect(
+  debug_inspect(
     compact_diffs,
-    content="[Equal(old_index=0, new_index=0, len=4), Insert(old_index=4, new_index=4, new_len=2), Equal(old_index=4, new_index=6, len=1), Delete(old_index=5, old_len=2, new_index=7)]",
+    content=(
+      #|[
+      #|  Equal(old_index=0, new_index=0, len=4),
+      #|  Insert(old_index=4, new_index=4, new_len=2),
+      #|  Equal(old_index=4, new_index=6, len=1),
+      #|  Delete(old_index=5, old_len=2, new_index=7),
+      #|]
+    ),
   )
 }


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
